### PR TITLE
Expose `Apply` operation and add documentation to it

### DIFF
--- a/apply.go
+++ b/apply.go
@@ -1,17 +1,25 @@
 package govec
 
-func (v V2F[T]) apply(f func(T) T) V2F[T] {
-	return V2F[T]{X: f(v.X), Y: f(v.Y)}
+// Apply applies a function to each component of a vector.
+// The function passed to Apply takes the component and the index of the component as arguments.
+func (v V2F[T]) Apply(f func(T, int8) T) V2F[T] {
+	return V2F[T]{X: f(v.X, 0), Y: f(v.Y, 1)}
 }
 
-func (v V3F[T]) apply(f func(T) T) V3F[T] {
-	return V3F[T]{X: f(v.X), Y: f(v.Y), Z: f(v.Z)}
+// Apply applies a function to each component of a vector.
+// The function passed to Apply takes the component and the index of the component as arguments.
+func (v V3F[T]) Apply(f func(T, int8) T) V3F[T] {
+	return V3F[T]{X: f(v.X, 0), Y: f(v.Y, 1), Z: f(v.Z, 2)}
 }
 
-func (v V2I[T]) apply(f func(T) T) V2I[T] {
-	return V2I[T]{X: f(v.X), Y: f(v.Y)}
+// Apply applies a function to each component of a vector.
+// The function passed to Apply takes the component and the index of the component as arguments.
+func (v V2I[T]) Apply(f func(T, int8) T) V2I[T] {
+	return V2I[T]{X: f(v.X, 0), Y: f(v.Y, 1)}
 }
 
-func (v V3I[T]) apply(f func(T) T) V3I[T] {
-	return V3I[T]{X: f(v.X), Y: f(v.Y), Z: f(v.Z)}
+// Apply applies a function to each component of a vector.
+// The function passed to Apply takes the component and the index of the component as arguments.
+func (v V3I[T]) Apply(f func(T, int8) T) V3I[T] {
+	return V3I[T]{X: f(v.X, 0), Y: f(v.Y, 1), Z: f(v.Z, 2)}
 }

--- a/apply.go
+++ b/apply.go
@@ -1,25 +1,25 @@
 package govec
 
 // Apply applies a function to each component of a vector.
-// The function passed to Apply takes the component and the index of the component as arguments.
-func (v V2F[T]) Apply(f func(T, int8) T) V2F[T] {
+// The function passed to Apply takes the component value and index as arguments.
+func (v V2F[T]) Apply(f func(compVal T, compIdx int8) T) V2F[T] {
 	return V2F[T]{X: f(v.X, 0), Y: f(v.Y, 1)}
 }
 
 // Apply applies a function to each component of a vector.
-// The function passed to Apply takes the component and the index of the component as arguments.
-func (v V3F[T]) Apply(f func(T, int8) T) V3F[T] {
+// The function passed to Apply takes the component value and index as arguments.
+func (v V3F[T]) Apply(f func(compVal T, compIdx int8) T) V3F[T] {
 	return V3F[T]{X: f(v.X, 0), Y: f(v.Y, 1), Z: f(v.Z, 2)}
 }
 
 // Apply applies a function to each component of a vector.
-// The function passed to Apply takes the component and the index of the component as arguments.
-func (v V2I[T]) Apply(f func(T, int8) T) V2I[T] {
+// The function passed to Apply takes the component value and index as arguments.
+func (v V2I[T]) Apply(f func(compVal T, compIdx int8) T) V2I[T] {
 	return V2I[T]{X: f(v.X, 0), Y: f(v.Y, 1)}
 }
 
 // Apply applies a function to each component of a vector.
-// The function passed to Apply takes the component and the index of the component as arguments.
-func (v V3I[T]) Apply(f func(T, int8) T) V3I[T] {
+// The function passed to Apply takes the component value and index as arguments.
+func (v V3I[T]) Apply(f func(compVal T, compIdx int8) T) V3I[T] {
 	return V3I[T]{X: f(v.X, 0), Y: f(v.Y, 1), Z: f(v.Z, 2)}
 }


### PR DESCRIPTION
- Exposed the `Apply` operation as it was starting with a lower case letter for some reason
- Added short documentation comments
- Function passed to the `Apply` now needs to additionally accept an index of a component. This is to allow differentiation between processing X Y and Z