### PR TITLE
Add 2D Vector rotation by radians operation

### DIFF
--- a/rotateRad.go
+++ b/rotateRad.go
@@ -5,17 +5,17 @@ import (
 )
 
 // RotateRad returns the vector obtained by rotating
-// the specified 2D vector anticlockwise by the angle
+// the specified 2D vector counterclockwise by the angle
 // specified in radians.
-func (v V2F[T]) RotateRad(angleRad float64) V2F[float64] {
-	return V2F[float64]{
-		X: float64(v.X)*math.Cos(angleRad) - float64(v.Y)*math.Sin(angleRad),
-		Y: float64(v.X)*math.Sin(angleRad) + float64(v.Y)*math.Cos(angleRad),
+func (v V2F[T]) RotateRad(angleRad float64) V2F[T] {
+	return V2F[T]{
+		X: T(float64(v.X)*math.Cos(angleRad) - float64(v.Y)*math.Sin(angleRad)),
+		Y: T(float64(v.X)*math.Sin(angleRad) + float64(v.Y)*math.Cos(angleRad)),
 	}
 }
 
 // RotateRad returns the vector obtained by rotating
-// the specified 2D vector anticlockwise by the angle
+// the specified 2D vector counterclockwise by the angle
 // specified in radians.
 func (v V2I[T]) RotateRad(angleRad float64) V2F[float64] {
 	return V2F[float64]{

--- a/rotateRad.go
+++ b/rotateRad.go
@@ -5,8 +5,8 @@ import (
 )
 
 // RotateRad returns the vector obtained by rotating
-// the specified 2D vector by the angle specified in
-// radians.
+// the specified 2D vector anticlockwise by the angle
+// specified in radians.
 func (v V2F[T]) RotateRad(angleRad float64) V2F[float64] {
 	return V2F[float64]{
 		X: float64(v.X)*math.Cos(angleRad) - float64(v.Y)*math.Sin(angleRad),
@@ -15,8 +15,8 @@ func (v V2F[T]) RotateRad(angleRad float64) V2F[float64] {
 }
 
 // RotateRad returns the vector obtained by rotating
-// the specified 2D vector by the angle specified in
-// radians.
+// the specified 2D vector anticlockwise by the angle
+// specified in radians.
 func (v V2I[T]) RotateRad(angleRad float64) V2F[float64] {
 	return V2F[float64]{
 		X: float64(v.X)*math.Cos(angleRad) - float64(v.Y)*math.Sin(angleRad),

--- a/rotateRad.go
+++ b/rotateRad.go
@@ -1,0 +1,25 @@
+package govec
+
+import (
+	"math"
+)
+
+// RotateRad returns the vector obtained by rotating
+// the specified 2D vector by the angle specified in
+// radians.
+func (v V2F[T]) RotateRad(angleRad float64) V2F[float64] {
+	return V2F[float64]{
+		X: float64(v.X)*math.Cos(angleRad) - float64(v.Y)*math.Sin(angleRad),
+		Y: float64(v.X)*math.Sin(angleRad) + float64(v.Y)*math.Cos(angleRad),
+	}
+}
+
+// RotateRad returns the vector obtained by rotating
+// the specified 2D vector by the angle specified in
+// radians.
+func (v V2I[T]) RotateRad(angleRad float64) V2F[float64] {
+	return V2F[float64]{
+		X: float64(v.X)*math.Cos(angleRad) - float64(v.Y)*math.Sin(angleRad),
+		Y: float64(v.X)*math.Sin(angleRad) + float64(v.Y)*math.Cos(angleRad),
+	}
+}


### PR DESCRIPTION
Added a file `rotateRad.go`:

1. Provides rotation by radians for 2D vectors only
2. Closes #24 