### PR TITLE
Implement RandIn and RandBetween operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,9 @@ in some cases the return type is different. Examples:
 | [`Pow3`](pow3.go)                       | Cubes each component of the vector.                                                                         |
 | [`PowN`](powN.go)                       | Raises each component of the vector to a specified integer power.                                           |
 | [`PowNFloat`](powNFloat.go)             | Raises each component of the vector to a specified floating-point power.                                    |
+| [`Rand`](rand.go)                       | Generates a normal vector with random components.                                                           |
+| [`RandBetween`](randBetween.go)         | Generates a vector with random components between two specified vectors.                                    |
+| [`RandIn`](randIn.go)                   | Generates a vector with random components within a zero and the specified vector.                           |
 | [`Round`](round.go)                     | Rounds each component of the vector to the nearest integer.                                                 |
 | [`Sin`](sin.go)                         | Applies the sine function to all components.                                                                |
 | [`Sqrt`](sqrt.go)                       | Computes the square root of each component in the vector.                                                   |
@@ -212,9 +215,9 @@ any of these implemented or if you'd like to propose a different operation.
 | `Lerp`           | Yes (v1.0) | Linearly interpolates between two vectors.                                        |
 | `Orthogonalize`  |            | Generates an orthogonal (or orthonormal) vector set.                              |
 | `Project`        |            | Projects a 3D vector onto a plane.                                                |
-| `Rand`           | Yes (v1.0) | Generates a normal vector with random components.                                 |
-| `RandIn`         | Yes (v1.0) | Generates a vector with random components within a zero and the specified vector. |
-| `RandBetween`    | Yes (v1.0) | Generates a vector with random components between two specified vectors.          |
+| [`Rand`](rand.go)           | Implemented | Generates a normal vector with random components.                                 |
+| [`RandIn`](randIn.go)         | Implemented | Generates a vector with random components within a zero and the specified vector. |
+| [`RandBetween`](randBetween.go)    | Implemented | Generates a vector with random components between two specified vectors.          |
 | `Reflect`        |            | Reflects a vector off the plane defined by a normal.                              |
 | `RotateDeg`      | Yes (v1.0) | Rotates a vector by an angle in degrees.                                          |
 | `RotateRad`      | Yes (v1.0) | Rotates a vector by an angle in radians.                                          |

--- a/randBetween.go
+++ b/randBetween.go
@@ -1,0 +1,286 @@
+package govec
+
+import (
+        "math/rand"
+        "time"
+)
+
+// RandBetween generates a vector with random components within a range specified by two vectors.
+// Each component of the returned vector will be a random value between the corresponding components of the two vectors.
+func (v V2F[T]) RandBetween(to V2F[T]) V2F[T] {
+        r := rand.New(rand.NewSource(time.Now().UnixNano()))
+        return V2F[T]{
+                X: v.X + T(r.Float64())*(to.X-v.X),
+                Y: v.Y + T(r.Float64())*(to.Y-v.Y),
+        }
+}
+
+// RandBetweenComp generates a vector with random components within a range specified by the vector and the provided components.
+// Each component of the returned vector will be a random value between the corresponding component of the vector and the provided component.
+func (v V2F[T]) RandBetweenComp(toX, toY T) V2F[T] {
+        r := rand.New(rand.NewSource(time.Now().UnixNano()))
+        return V2F[T]{
+                X: v.X + T(r.Float64())*(toX-v.X),
+                Y: v.Y + T(r.Float64())*(toY-v.Y),
+        }
+}
+
+// RandBetweenInPlace updates the vector with random components within a range specified by the vector and another vector.
+// Each component of the vector will be set to a random value between its current value and the corresponding component of the provided vector.
+func (v *V2F[T]) RandBetweenInPlace(to V2F[T]) {
+        r := rand.New(rand.NewSource(time.Now().UnixNano()))
+        v.X = v.X + T(r.Float64())*(to.X-v.X)
+        v.Y = v.Y + T(r.Float64())*(to.Y-v.Y)
+}
+
+// RandBetweenCompInPlace updates the vector with random components within a range specified by the vector and the provided components.
+// Each component of the vector will be set to a random value between its current value and the provided component.
+func (v *V2F[T]) RandBetweenCompInPlace(toX, toY T) {
+        r := rand.New(rand.NewSource(time.Now().UnixNano()))
+        v.X = v.X + T(r.Float64())*(toX-v.X)
+        v.Y = v.Y + T(r.Float64())*(toY-v.Y)
+}
+
+// RandBetween generates a vector with random components within a range specified by two vectors.
+// Each component of the returned vector will be a random value between the corresponding components of the two vectors.
+func (v V3F[T]) RandBetween(to V3F[T]) V3F[T] {
+        r := rand.New(rand.NewSource(time.Now().UnixNano()))
+        return V3F[T]{
+                X: v.X + T(r.Float64())*(to.X-v.X),
+                Y: v.Y + T(r.Float64())*(to.Y-v.Y),
+                Z: v.Z + T(r.Float64())*(to.Z-v.Z),
+        }
+}
+
+// RandBetweenComp generates a vector with random components within a range specified by the vector and the provided components.
+// Each component of the returned vector will be a random value between the corresponding component of the vector and the provided component.
+func (v V3F[T]) RandBetweenComp(toX, toY, toZ T) V3F[T] {
+        r := rand.New(rand.NewSource(time.Now().UnixNano()))
+        return V3F[T]{
+                X: v.X + T(r.Float64())*(toX-v.X),
+                Y: v.Y + T(r.Float64())*(toY-v.Y),
+                Z: v.Z + T(r.Float64())*(toZ-v.Z),
+        }
+}
+
+// RandBetweenInPlace updates the vector with random components within a range specified by the vector and another vector.
+// Each component of the vector will be set to a random value between its current value and the corresponding component of the provided vector.
+func (v *V3F[T]) RandBetweenInPlace(to V3F[T]) {
+        r := rand.New(rand.NewSource(time.Now().UnixNano()))
+        v.X = v.X + T(r.Float64())*(to.X-v.X)
+        v.Y = v.Y + T(r.Float64())*(to.Y-v.Y)
+        v.Z = v.Z + T(r.Float64())*(to.Z-v.Z)
+}
+
+// RandBetweenCompInPlace updates the vector with random components within a range specified by the vector and the provided components.
+// Each component of the vector will be set to a random value between its current value and the provided component.
+func (v *V3F[T]) RandBetweenCompInPlace(toX, toY, toZ T) {
+        r := rand.New(rand.NewSource(time.Now().UnixNano()))
+        v.X = v.X + T(r.Float64())*(toX-v.X)
+        v.Y = v.Y + T(r.Float64())*(toY-v.Y)
+        v.Z = v.Z + T(r.Float64())*(toZ-v.Z)
+}
+
+// RandBetween generates a vector with random components within a range specified by two vectors.
+// Each component of the returned vector will be a random value between the corresponding components of the two vectors.
+func (v V2I[T]) RandBetween(to V2I[T]) V2I[T] {
+        r := rand.New(rand.NewSource(time.Now().UnixNano()))
+        
+        // Calculate the range for each component
+        rangeX := int64(to.X) - int64(v.X)
+        rangeY := int64(to.Y) - int64(v.Y)
+        
+        // Generate random values within the range
+        randX := int64(v.X)
+        if rangeX > 0 {
+                randX += r.Int63n(rangeX + 1)
+        }
+        
+        randY := int64(v.Y)
+        if rangeY > 0 {
+                randY += r.Int63n(rangeY + 1)
+        }
+        
+        return V2I[T]{
+                X: T(randX),
+                Y: T(randY),
+        }
+}
+
+// RandBetweenComp generates a vector with random components within a range specified by the vector and the provided components.
+// Each component of the returned vector will be a random value between the corresponding component of the vector and the provided component.
+func (v V2I[T]) RandBetweenComp(toX, toY T) V2I[T] {
+        r := rand.New(rand.NewSource(time.Now().UnixNano()))
+        
+        // Calculate the range for each component
+        rangeX := int64(toX) - int64(v.X)
+        rangeY := int64(toY) - int64(v.Y)
+        
+        // Generate random values within the range
+        randX := int64(v.X)
+        if rangeX > 0 {
+                randX += r.Int63n(rangeX + 1)
+        }
+        
+        randY := int64(v.Y)
+        if rangeY > 0 {
+                randY += r.Int63n(rangeY + 1)
+        }
+        
+        return V2I[T]{
+                X: T(randX),
+                Y: T(randY),
+        }
+}
+
+// RandBetweenInPlace updates the vector with random components within a range specified by the vector and another vector.
+// Each component of the vector will be set to a random value between its current value and the corresponding component of the provided vector.
+func (v *V2I[T]) RandBetweenInPlace(to V2I[T]) {
+        r := rand.New(rand.NewSource(time.Now().UnixNano()))
+        
+        // Calculate the range for each component
+        rangeX := int64(to.X) - int64(v.X)
+        rangeY := int64(to.Y) - int64(v.Y)
+        
+        // Generate random values within the range and update the vector
+        if rangeX > 0 {
+                v.X = T(int64(v.X) + r.Int63n(rangeX+1))
+        }
+        
+        if rangeY > 0 {
+                v.Y = T(int64(v.Y) + r.Int63n(rangeY+1))
+        }
+}
+
+// RandBetweenCompInPlace updates the vector with random components within a range specified by the vector and the provided components.
+// Each component of the vector will be set to a random value between its current value and the provided component.
+func (v *V2I[T]) RandBetweenCompInPlace(toX, toY T) {
+        r := rand.New(rand.NewSource(time.Now().UnixNano()))
+        
+        // Calculate the range for each component
+        rangeX := int64(toX) - int64(v.X)
+        rangeY := int64(toY) - int64(v.Y)
+        
+        // Generate random values within the range and update the vector
+        if rangeX > 0 {
+                v.X = T(int64(v.X) + r.Int63n(rangeX+1))
+        }
+        
+        if rangeY > 0 {
+                v.Y = T(int64(v.Y) + r.Int63n(rangeY+1))
+        }
+}
+
+// RandBetween generates a vector with random components within a range specified by two vectors.
+// Each component of the returned vector will be a random value between the corresponding components of the two vectors.
+func (v V3I[T]) RandBetween(to V3I[T]) V3I[T] {
+        r := rand.New(rand.NewSource(time.Now().UnixNano()))
+        
+        // Calculate the range for each component
+        rangeX := int64(to.X) - int64(v.X)
+        rangeY := int64(to.Y) - int64(v.Y)
+        rangeZ := int64(to.Z) - int64(v.Z)
+        
+        // Generate random values within the range
+        randX := int64(v.X)
+        if rangeX > 0 {
+                randX += r.Int63n(rangeX + 1)
+        }
+        
+        randY := int64(v.Y)
+        if rangeY > 0 {
+                randY += r.Int63n(rangeY + 1)
+        }
+        
+        randZ := int64(v.Z)
+        if rangeZ > 0 {
+                randZ += r.Int63n(rangeZ + 1)
+        }
+        
+        return V3I[T]{
+                X: T(randX),
+                Y: T(randY),
+                Z: T(randZ),
+        }
+}
+
+// RandBetweenComp generates a vector with random components within a range specified by the vector and the provided components.
+// Each component of the returned vector will be a random value between the corresponding component of the vector and the provided component.
+func (v V3I[T]) RandBetweenComp(toX, toY, toZ T) V3I[T] {
+        r := rand.New(rand.NewSource(time.Now().UnixNano()))
+        
+        // Calculate the range for each component
+        rangeX := int64(toX) - int64(v.X)
+        rangeY := int64(toY) - int64(v.Y)
+        rangeZ := int64(toZ) - int64(v.Z)
+        
+        // Generate random values within the range
+        randX := int64(v.X)
+        if rangeX > 0 {
+                randX += r.Int63n(rangeX + 1)
+        }
+        
+        randY := int64(v.Y)
+        if rangeY > 0 {
+                randY += r.Int63n(rangeY + 1)
+        }
+        
+        randZ := int64(v.Z)
+        if rangeZ > 0 {
+                randZ += r.Int63n(rangeZ + 1)
+        }
+        
+        return V3I[T]{
+                X: T(randX),
+                Y: T(randY),
+                Z: T(randZ),
+        }
+}
+
+// RandBetweenInPlace updates the vector with random components within a range specified by the vector and another vector.
+// Each component of the vector will be set to a random value between its current value and the corresponding component of the provided vector.
+func (v *V3I[T]) RandBetweenInPlace(to V3I[T]) {
+        r := rand.New(rand.NewSource(time.Now().UnixNano()))
+        
+        // Calculate the range for each component
+        rangeX := int64(to.X) - int64(v.X)
+        rangeY := int64(to.Y) - int64(v.Y)
+        rangeZ := int64(to.Z) - int64(v.Z)
+        
+        // Generate random values within the range and update the vector
+        if rangeX > 0 {
+                v.X = T(int64(v.X) + r.Int63n(rangeX+1))
+        }
+        
+        if rangeY > 0 {
+                v.Y = T(int64(v.Y) + r.Int63n(rangeY+1))
+        }
+        
+        if rangeZ > 0 {
+                v.Z = T(int64(v.Z) + r.Int63n(rangeZ+1))
+        }
+}
+
+// RandBetweenCompInPlace updates the vector with random components within a range specified by the vector and the provided components.
+// Each component of the vector will be set to a random value between its current value and the provided component.
+func (v *V3I[T]) RandBetweenCompInPlace(toX, toY, toZ T) {
+        r := rand.New(rand.NewSource(time.Now().UnixNano()))
+        
+        // Calculate the range for each component
+        rangeX := int64(toX) - int64(v.X)
+        rangeY := int64(toY) - int64(v.Y)
+        rangeZ := int64(toZ) - int64(v.Z)
+        
+        // Generate random values within the range and update the vector
+        if rangeX > 0 {
+                v.X = T(int64(v.X) + r.Int63n(rangeX+1))
+        }
+        
+        if rangeY > 0 {
+                v.Y = T(int64(v.Y) + r.Int63n(rangeY+1))
+        }
+        
+        if rangeZ > 0 {
+                v.Z = T(int64(v.Z) + r.Int63n(rangeZ+1))
+        }
+}

--- a/randBetween_test.go
+++ b/randBetween_test.go
@@ -1,0 +1,366 @@
+package govec
+
+import (
+	"testing"
+)
+
+func Test_V2F_RandBetween(t *testing.T) {
+	t.Run("RandBetween should generate random values within range for V2F[float32]", func(t *testing.T) {
+		from := V2F[float32]{10.0, 20.0}
+		to := V2F[float32]{30.0, 40.0}
+		
+		// Generate multiple random vectors to ensure randomness
+		for i := 0; i < 10; i++ {
+			r := from.RandBetween(to)
+			
+			// Check that components are within range [from.X, to.X] and [from.Y, to.Y]
+			if r.X < from.X || r.X > to.X {
+				t.Errorf("Expected X component to be in range [%f, %f], got %f", from.X, to.X, r.X)
+			}
+			if r.Y < from.Y || r.Y > to.Y {
+				t.Errorf("Expected Y component to be in range [%f, %f], got %f", from.Y, to.Y, r.Y)
+			}
+		}
+	})
+	
+	t.Run("RandBetween should generate random values within range for V2F[float64]", func(t *testing.T) {
+		from := V2F[float64]{10.0, 20.0}
+		to := V2F[float64]{30.0, 40.0}
+		
+		// Generate multiple random vectors to ensure randomness
+		for i := 0; i < 10; i++ {
+			r := from.RandBetween(to)
+			
+			// Check that components are within range [from.X, to.X] and [from.Y, to.Y]
+			if r.X < from.X || r.X > to.X {
+				t.Errorf("Expected X component to be in range [%f, %f], got %f", from.X, to.X, r.X)
+			}
+			if r.Y < from.Y || r.Y > to.Y {
+				t.Errorf("Expected Y component to be in range [%f, %f], got %f", from.Y, to.Y, r.Y)
+			}
+		}
+	})
+	
+	t.Run("RandBetweenComp should generate random values within range for V2F[float32]", func(t *testing.T) {
+		from := V2F[float32]{10.0, 20.0}
+		toX, toY := float32(30.0), float32(40.0)
+		
+		// Generate multiple random vectors to ensure randomness
+		for i := 0; i < 10; i++ {
+			r := from.RandBetweenComp(toX, toY)
+			
+			// Check that components are within range [from.X, toX] and [from.Y, toY]
+			if r.X < from.X || r.X > toX {
+				t.Errorf("Expected X component to be in range [%f, %f], got %f", from.X, toX, r.X)
+			}
+			if r.Y < from.Y || r.Y > toY {
+				t.Errorf("Expected Y component to be in range [%f, %f], got %f", from.Y, toY, r.Y)
+			}
+		}
+	})
+	
+	t.Run("RandBetweenInPlace should modify the vector in-place for V2F[float32]", func(t *testing.T) {
+		from := V2F[float32]{10.0, 20.0}
+		to := V2F[float32]{30.0, 40.0}
+		original := V2F[float32]{from.X, from.Y}
+		
+		from.RandBetweenInPlace(to)
+		
+		// Check that components are within range [original.X, to.X] and [original.Y, to.Y]
+		if from.X < original.X || from.X > to.X {
+			t.Errorf("Expected X component to be in range [%f, %f], got %f", original.X, to.X, from.X)
+		}
+		if from.Y < original.Y || from.Y > to.Y {
+			t.Errorf("Expected Y component to be in range [%f, %f], got %f", original.Y, to.Y, from.Y)
+		}
+	})
+	
+	t.Run("RandBetweenCompInPlace should modify the vector in-place for V2F[float32]", func(t *testing.T) {
+		from := V2F[float32]{10.0, 20.0}
+		toX, toY := float32(30.0), float32(40.0)
+		original := V2F[float32]{from.X, from.Y}
+		
+		from.RandBetweenCompInPlace(toX, toY)
+		
+		// Check that components are within range [original.X, toX] and [original.Y, toY]
+		if from.X < original.X || from.X > toX {
+			t.Errorf("Expected X component to be in range [%f, %f], got %f", original.X, toX, from.X)
+		}
+		if from.Y < original.Y || from.Y > toY {
+			t.Errorf("Expected Y component to be in range [%f, %f], got %f", original.Y, toY, from.Y)
+		}
+	})
+}
+
+func Test_V3F_RandBetween(t *testing.T) {
+	t.Run("RandBetween should generate random values within range for V3F[float32]", func(t *testing.T) {
+		from := V3F[float32]{10.0, 20.0, 30.0}
+		to := V3F[float32]{40.0, 50.0, 60.0}
+		
+		// Generate multiple random vectors to ensure randomness
+		for i := 0; i < 10; i++ {
+			r := from.RandBetween(to)
+			
+			// Check that components are within range [from.X, to.X], [from.Y, to.Y], and [from.Z, to.Z]
+			if r.X < from.X || r.X > to.X {
+				t.Errorf("Expected X component to be in range [%f, %f], got %f", from.X, to.X, r.X)
+			}
+			if r.Y < from.Y || r.Y > to.Y {
+				t.Errorf("Expected Y component to be in range [%f, %f], got %f", from.Y, to.Y, r.Y)
+			}
+			if r.Z < from.Z || r.Z > to.Z {
+				t.Errorf("Expected Z component to be in range [%f, %f], got %f", from.Z, to.Z, r.Z)
+			}
+		}
+	})
+	
+	t.Run("RandBetweenComp should generate random values within range for V3F[float32]", func(t *testing.T) {
+		from := V3F[float32]{10.0, 20.0, 30.0}
+		toX, toY, toZ := float32(40.0), float32(50.0), float32(60.0)
+		
+		// Generate multiple random vectors to ensure randomness
+		for i := 0; i < 10; i++ {
+			r := from.RandBetweenComp(toX, toY, toZ)
+			
+			// Check that components are within range [from.X, toX], [from.Y, toY], and [from.Z, toZ]
+			if r.X < from.X || r.X > toX {
+				t.Errorf("Expected X component to be in range [%f, %f], got %f", from.X, toX, r.X)
+			}
+			if r.Y < from.Y || r.Y > toY {
+				t.Errorf("Expected Y component to be in range [%f, %f], got %f", from.Y, toY, r.Y)
+			}
+			if r.Z < from.Z || r.Z > toZ {
+				t.Errorf("Expected Z component to be in range [%f, %f], got %f", from.Z, toZ, r.Z)
+			}
+		}
+	})
+	
+	t.Run("RandBetweenInPlace should modify the vector in-place for V3F[float32]", func(t *testing.T) {
+		from := V3F[float32]{10.0, 20.0, 30.0}
+		to := V3F[float32]{40.0, 50.0, 60.0}
+		original := V3F[float32]{from.X, from.Y, from.Z}
+		
+		from.RandBetweenInPlace(to)
+		
+		// Check that components are within range [original.X, to.X], [original.Y, to.Y], and [original.Z, to.Z]
+		if from.X < original.X || from.X > to.X {
+			t.Errorf("Expected X component to be in range [%f, %f], got %f", original.X, to.X, from.X)
+		}
+		if from.Y < original.Y || from.Y > to.Y {
+			t.Errorf("Expected Y component to be in range [%f, %f], got %f", original.Y, to.Y, from.Y)
+		}
+		if from.Z < original.Z || from.Z > to.Z {
+			t.Errorf("Expected Z component to be in range [%f, %f], got %f", original.Z, to.Z, from.Z)
+		}
+	})
+	
+	t.Run("RandBetweenCompInPlace should modify the vector in-place for V3F[float32]", func(t *testing.T) {
+		from := V3F[float32]{10.0, 20.0, 30.0}
+		toX, toY, toZ := float32(40.0), float32(50.0), float32(60.0)
+		original := V3F[float32]{from.X, from.Y, from.Z}
+		
+		from.RandBetweenCompInPlace(toX, toY, toZ)
+		
+		// Check that components are within range [original.X, toX], [original.Y, toY], and [original.Z, toZ]
+		if from.X < original.X || from.X > toX {
+			t.Errorf("Expected X component to be in range [%f, %f], got %f", original.X, toX, from.X)
+		}
+		if from.Y < original.Y || from.Y > toY {
+			t.Errorf("Expected Y component to be in range [%f, %f], got %f", original.Y, toY, from.Y)
+		}
+		if from.Z < original.Z || from.Z > toZ {
+			t.Errorf("Expected Z component to be in range [%f, %f], got %f", original.Z, toZ, from.Z)
+		}
+	})
+}
+
+func Test_V2I_RandBetween(t *testing.T) {
+	t.Run("RandBetween should generate random values within range for V2I[int]", func(t *testing.T) {
+		from := V2I[int]{10, 20}
+		to := V2I[int]{30, 40}
+		
+		// Generate multiple random vectors to ensure randomness
+		for i := 0; i < 10; i++ {
+			r := from.RandBetween(to)
+			
+			// Check that components are within range [from.X, to.X] and [from.Y, to.Y]
+			if r.X < from.X || r.X > to.X {
+				t.Errorf("Expected X component to be in range [%d, %d], got %d", from.X, to.X, r.X)
+			}
+			if r.Y < from.Y || r.Y > to.Y {
+				t.Errorf("Expected Y component to be in range [%d, %d], got %d", from.Y, to.Y, r.Y)
+			}
+		}
+	})
+	
+	t.Run("RandBetweenComp should generate random values within range for V2I[int]", func(t *testing.T) {
+		from := V2I[int]{10, 20}
+		toX, toY := 30, 40
+		
+		// Generate multiple random vectors to ensure randomness
+		for i := 0; i < 10; i++ {
+			r := from.RandBetweenComp(toX, toY)
+			
+			// Check that components are within range [from.X, toX] and [from.Y, toY]
+			if r.X < from.X || r.X > toX {
+				t.Errorf("Expected X component to be in range [%d, %d], got %d", from.X, toX, r.X)
+			}
+			if r.Y < from.Y || r.Y > toY {
+				t.Errorf("Expected Y component to be in range [%d, %d], got %d", from.Y, toY, r.Y)
+			}
+		}
+	})
+	
+	t.Run("RandBetweenInPlace should modify the vector in-place for V2I[int]", func(t *testing.T) {
+		from := V2I[int]{10, 20}
+		to := V2I[int]{30, 40}
+		original := V2I[int]{from.X, from.Y}
+		
+		from.RandBetweenInPlace(to)
+		
+		// Check that components are within range [original.X, to.X] and [original.Y, to.Y]
+		if from.X < original.X || from.X > to.X {
+			t.Errorf("Expected X component to be in range [%d, %d], got %d", original.X, to.X, from.X)
+		}
+		if from.Y < original.Y || from.Y > to.Y {
+			t.Errorf("Expected Y component to be in range [%d, %d], got %d", original.Y, to.Y, from.Y)
+		}
+	})
+	
+	t.Run("RandBetweenCompInPlace should modify the vector in-place for V2I[int]", func(t *testing.T) {
+		from := V2I[int]{10, 20}
+		toX, toY := 30, 40
+		original := V2I[int]{from.X, from.Y}
+		
+		from.RandBetweenCompInPlace(toX, toY)
+		
+		// Check that components are within range [original.X, toX] and [original.Y, toY]
+		if from.X < original.X || from.X > toX {
+			t.Errorf("Expected X component to be in range [%d, %d], got %d", original.X, toX, from.X)
+		}
+		if from.Y < original.Y || from.Y > toY {
+			t.Errorf("Expected Y component to be in range [%d, %d], got %d", original.Y, toY, from.Y)
+		}
+	})
+	
+	t.Run("RandBetween should handle reversed ranges correctly for V2I[int]", func(t *testing.T) {
+		from := V2I[int]{30, 40}
+		to := V2I[int]{10, 20}
+		
+		// Generate multiple random vectors to ensure randomness
+		for i := 0; i < 10; i++ {
+			r := from.RandBetween(to)
+			
+			// When from > to, the result should be equal to from
+			if r.X != from.X {
+				t.Errorf("Expected X component to be %d (from.X), got %d", from.X, r.X)
+			}
+			if r.Y != from.Y {
+				t.Errorf("Expected Y component to be %d (from.Y), got %d", from.Y, r.Y)
+			}
+		}
+	})
+}
+
+func Test_V3I_RandBetween(t *testing.T) {
+	t.Run("RandBetween should generate random values within range for V3I[int]", func(t *testing.T) {
+		from := V3I[int]{10, 20, 30}
+		to := V3I[int]{40, 50, 60}
+		
+		// Generate multiple random vectors to ensure randomness
+		for i := 0; i < 10; i++ {
+			r := from.RandBetween(to)
+			
+			// Check that components are within range [from.X, to.X], [from.Y, to.Y], and [from.Z, to.Z]
+			if r.X < from.X || r.X > to.X {
+				t.Errorf("Expected X component to be in range [%d, %d], got %d", from.X, to.X, r.X)
+			}
+			if r.Y < from.Y || r.Y > to.Y {
+				t.Errorf("Expected Y component to be in range [%d, %d], got %d", from.Y, to.Y, r.Y)
+			}
+			if r.Z < from.Z || r.Z > to.Z {
+				t.Errorf("Expected Z component to be in range [%d, %d], got %d", from.Z, to.Z, r.Z)
+			}
+		}
+	})
+	
+	t.Run("RandBetweenComp should generate random values within range for V3I[int]", func(t *testing.T) {
+		from := V3I[int]{10, 20, 30}
+		toX, toY, toZ := 40, 50, 60
+		
+		// Generate multiple random vectors to ensure randomness
+		for i := 0; i < 10; i++ {
+			r := from.RandBetweenComp(toX, toY, toZ)
+			
+			// Check that components are within range [from.X, toX], [from.Y, toY], and [from.Z, toZ]
+			if r.X < from.X || r.X > toX {
+				t.Errorf("Expected X component to be in range [%d, %d], got %d", from.X, toX, r.X)
+			}
+			if r.Y < from.Y || r.Y > toY {
+				t.Errorf("Expected Y component to be in range [%d, %d], got %d", from.Y, toY, r.Y)
+			}
+			if r.Z < from.Z || r.Z > toZ {
+				t.Errorf("Expected Z component to be in range [%d, %d], got %d", from.Z, toZ, r.Z)
+			}
+		}
+	})
+	
+	t.Run("RandBetweenInPlace should modify the vector in-place for V3I[int]", func(t *testing.T) {
+		from := V3I[int]{10, 20, 30}
+		to := V3I[int]{40, 50, 60}
+		original := V3I[int]{from.X, from.Y, from.Z}
+		
+		from.RandBetweenInPlace(to)
+		
+		// Check that components are within range [original.X, to.X], [original.Y, to.Y], and [original.Z, to.Z]
+		if from.X < original.X || from.X > to.X {
+			t.Errorf("Expected X component to be in range [%d, %d], got %d", original.X, to.X, from.X)
+		}
+		if from.Y < original.Y || from.Y > to.Y {
+			t.Errorf("Expected Y component to be in range [%d, %d], got %d", original.Y, to.Y, from.Y)
+		}
+		if from.Z < original.Z || from.Z > to.Z {
+			t.Errorf("Expected Z component to be in range [%d, %d], got %d", original.Z, to.Z, from.Z)
+		}
+	})
+	
+	t.Run("RandBetweenCompInPlace should modify the vector in-place for V3I[int]", func(t *testing.T) {
+		from := V3I[int]{10, 20, 30}
+		toX, toY, toZ := 40, 50, 60
+		original := V3I[int]{from.X, from.Y, from.Z}
+		
+		from.RandBetweenCompInPlace(toX, toY, toZ)
+		
+		// Check that components are within range [original.X, toX], [original.Y, toY], and [original.Z, toZ]
+		if from.X < original.X || from.X > toX {
+			t.Errorf("Expected X component to be in range [%d, %d], got %d", original.X, toX, from.X)
+		}
+		if from.Y < original.Y || from.Y > toY {
+			t.Errorf("Expected Y component to be in range [%d, %d], got %d", original.Y, toY, from.Y)
+		}
+		if from.Z < original.Z || from.Z > toZ {
+			t.Errorf("Expected Z component to be in range [%d, %d], got %d", original.Z, toZ, from.Z)
+		}
+	})
+	
+	t.Run("RandBetween should handle reversed ranges correctly for V3I[int]", func(t *testing.T) {
+		from := V3I[int]{40, 50, 60}
+		to := V3I[int]{10, 20, 30}
+		
+		// Generate multiple random vectors to ensure randomness
+		for i := 0; i < 10; i++ {
+			r := from.RandBetween(to)
+			
+			// When from > to, the result should be equal to from
+			if r.X != from.X {
+				t.Errorf("Expected X component to be %d (from.X), got %d", from.X, r.X)
+			}
+			if r.Y != from.Y {
+				t.Errorf("Expected Y component to be %d (from.Y), got %d", from.Y, r.Y)
+			}
+			if r.Z != from.Z {
+				t.Errorf("Expected Z component to be %d (from.Z), got %d", from.Z, r.Z)
+			}
+		}
+	})
+}

--- a/randIn.go
+++ b/randIn.go
@@ -1,0 +1,82 @@
+package govec
+
+import (
+        "math/rand"
+        "time"
+)
+
+// RandIn generates a vector with random components within a range specified by the vector and a zero vector.
+// Each component of the returned vector will be a random value between 0 and the corresponding component of the vector.
+func (v V2F[T]) RandIn() V2F[T] {
+        r := rand.New(rand.NewSource(time.Now().UnixNano()))
+        return V2F[T]{
+                X: T(r.Float64()) * v.X,
+                Y: T(r.Float64()) * v.Y,
+        }
+}
+
+// RandInInPlace updates the vector with random components within a range specified by the vector and a zero vector.
+// Each component of the vector will be set to a random value between 0 and its current value.
+func (v *V2F[T]) RandInInPlace() {
+        r := rand.New(rand.NewSource(time.Now().UnixNano()))
+        v.X = T(r.Float64()) * v.X
+        v.Y = T(r.Float64()) * v.Y
+}
+
+// RandIn generates a vector with random components within a range specified by the vector and a zero vector.
+// Each component of the returned vector will be a random value between 0 and the corresponding component of the vector.
+func (v V3F[T]) RandIn() V3F[T] {
+        r := rand.New(rand.NewSource(time.Now().UnixNano()))
+        return V3F[T]{
+                X: T(r.Float64()) * v.X,
+                Y: T(r.Float64()) * v.Y,
+                Z: T(r.Float64()) * v.Z,
+        }
+}
+
+// RandInInPlace updates the vector with random components within a range specified by the vector and a zero vector.
+// Each component of the vector will be set to a random value between 0 and its current value.
+func (v *V3F[T]) RandInInPlace() {
+        r := rand.New(rand.NewSource(time.Now().UnixNano()))
+        v.X = T(r.Float64()) * v.X
+        v.Y = T(r.Float64()) * v.Y
+        v.Z = T(r.Float64()) * v.Z
+}
+
+// RandIn generates a vector with random components within a range specified by the vector and a zero vector.
+// Each component of the returned vector will be a random value between 0 and the corresponding component of the vector.
+func (v V2I[T]) RandIn() V2I[T] {
+        r := rand.New(rand.NewSource(time.Now().UnixNano()))
+        return V2I[T]{
+                X: T(r.Int63n(int64(v.X) + 1)),
+                Y: T(r.Int63n(int64(v.Y) + 1)),
+        }
+}
+
+// RandInInPlace updates the vector with random components within a range specified by the vector and a zero vector.
+// Each component of the vector will be set to a random value between 0 and its current value.
+func (v *V2I[T]) RandInInPlace() {
+        r := rand.New(rand.NewSource(time.Now().UnixNano()))
+        v.X = T(r.Int63n(int64(v.X) + 1))
+        v.Y = T(r.Int63n(int64(v.Y) + 1))
+}
+
+// RandIn generates a vector with random components within a range specified by the vector and a zero vector.
+// Each component of the returned vector will be a random value between 0 and the corresponding component of the vector.
+func (v V3I[T]) RandIn() V3I[T] {
+        r := rand.New(rand.NewSource(time.Now().UnixNano()))
+        return V3I[T]{
+                X: T(r.Int63n(int64(v.X) + 1)),
+                Y: T(r.Int63n(int64(v.Y) + 1)),
+                Z: T(r.Int63n(int64(v.Z) + 1)),
+        }
+}
+
+// RandInInPlace updates the vector with random components within a range specified by the vector and a zero vector.
+// Each component of the vector will be set to a random value between 0 and its current value.
+func (v *V3I[T]) RandInInPlace() {
+        r := rand.New(rand.NewSource(time.Now().UnixNano()))
+        v.X = T(r.Int63n(int64(v.X) + 1))
+        v.Y = T(r.Int63n(int64(v.Y) + 1))
+        v.Z = T(r.Int63n(int64(v.Z) + 1))
+}

--- a/randIn_test.go
+++ b/randIn_test.go
@@ -1,0 +1,227 @@
+package govec
+
+import (
+	"testing"
+)
+
+func Test_V2F_RandIn(t *testing.T) {
+	t.Run("RandIn should generate random values within range for V2F[float32]", func(t *testing.T) {
+		v := V2F[float32]{10.0, 20.0}
+		
+		// Generate multiple random vectors to ensure randomness
+		for i := 0; i < 10; i++ {
+			r := v.RandIn()
+			
+			// Check that components are within range [0, v.X] and [0, v.Y]
+			if r.X < 0 || r.X > v.X {
+				t.Errorf("Expected X component to be in range [0, %f], got %f", v.X, r.X)
+			}
+			if r.Y < 0 || r.Y > v.Y {
+				t.Errorf("Expected Y component to be in range [0, %f], got %f", v.Y, r.Y)
+			}
+		}
+	})
+	
+	t.Run("RandIn should generate random values within range for V2F[float64]", func(t *testing.T) {
+		v := V2F[float64]{10.0, 20.0}
+		
+		// Generate multiple random vectors to ensure randomness
+		for i := 0; i < 10; i++ {
+			r := v.RandIn()
+			
+			// Check that components are within range [0, v.X] and [0, v.Y]
+			if r.X < 0 || r.X > v.X {
+				t.Errorf("Expected X component to be in range [0, %f], got %f", v.X, r.X)
+			}
+			if r.Y < 0 || r.Y > v.Y {
+				t.Errorf("Expected Y component to be in range [0, %f], got %f", v.Y, r.Y)
+			}
+		}
+	})
+	
+	t.Run("RandInInPlace should modify the vector in-place for V2F[float32]", func(t *testing.T) {
+		v := V2F[float32]{10.0, 20.0}
+		original := V2F[float32]{v.X, v.Y}
+		
+		v.RandInInPlace()
+		
+		// Check that components are within range [0, original.X] and [0, original.Y]
+		if v.X < 0 || v.X > original.X {
+			t.Errorf("Expected X component to be in range [0, %f], got %f", original.X, v.X)
+		}
+		if v.Y < 0 || v.Y > original.Y {
+			t.Errorf("Expected Y component to be in range [0, %f], got %f", original.Y, v.Y)
+		}
+	})
+}
+
+func Test_V3F_RandIn(t *testing.T) {
+	t.Run("RandIn should generate random values within range for V3F[float32]", func(t *testing.T) {
+		v := V3F[float32]{10.0, 20.0, 30.0}
+		
+		// Generate multiple random vectors to ensure randomness
+		for i := 0; i < 10; i++ {
+			r := v.RandIn()
+			
+			// Check that components are within range [0, v.X], [0, v.Y], and [0, v.Z]
+			if r.X < 0 || r.X > v.X {
+				t.Errorf("Expected X component to be in range [0, %f], got %f", v.X, r.X)
+			}
+			if r.Y < 0 || r.Y > v.Y {
+				t.Errorf("Expected Y component to be in range [0, %f], got %f", v.Y, r.Y)
+			}
+			if r.Z < 0 || r.Z > v.Z {
+				t.Errorf("Expected Z component to be in range [0, %f], got %f", v.Z, r.Z)
+			}
+		}
+	})
+	
+	t.Run("RandIn should generate random values within range for V3F[float64]", func(t *testing.T) {
+		v := V3F[float64]{10.0, 20.0, 30.0}
+		
+		// Generate multiple random vectors to ensure randomness
+		for i := 0; i < 10; i++ {
+			r := v.RandIn()
+			
+			// Check that components are within range [0, v.X], [0, v.Y], and [0, v.Z]
+			if r.X < 0 || r.X > v.X {
+				t.Errorf("Expected X component to be in range [0, %f], got %f", v.X, r.X)
+			}
+			if r.Y < 0 || r.Y > v.Y {
+				t.Errorf("Expected Y component to be in range [0, %f], got %f", v.Y, r.Y)
+			}
+			if r.Z < 0 || r.Z > v.Z {
+				t.Errorf("Expected Z component to be in range [0, %f], got %f", v.Z, r.Z)
+			}
+		}
+	})
+	
+	t.Run("RandInInPlace should modify the vector in-place for V3F[float32]", func(t *testing.T) {
+		v := V3F[float32]{10.0, 20.0, 30.0}
+		original := V3F[float32]{v.X, v.Y, v.Z}
+		
+		v.RandInInPlace()
+		
+		// Check that components are within range [0, original.X], [0, original.Y], and [0, original.Z]
+		if v.X < 0 || v.X > original.X {
+			t.Errorf("Expected X component to be in range [0, %f], got %f", original.X, v.X)
+		}
+		if v.Y < 0 || v.Y > original.Y {
+			t.Errorf("Expected Y component to be in range [0, %f], got %f", original.Y, v.Y)
+		}
+		if v.Z < 0 || v.Z > original.Z {
+			t.Errorf("Expected Z component to be in range [0, %f], got %f", original.Z, v.Z)
+		}
+	})
+}
+
+func Test_V2I_RandIn(t *testing.T) {
+	t.Run("RandIn should generate random values within range for V2I[int]", func(t *testing.T) {
+		v := V2I[int]{10, 20}
+		
+		// Generate multiple random vectors to ensure randomness
+		for i := 0; i < 10; i++ {
+			r := v.RandIn()
+			
+			// Check that components are within range [0, v.X] and [0, v.Y]
+			if r.X < 0 || r.X > v.X {
+				t.Errorf("Expected X component to be in range [0, %d], got %d", v.X, r.X)
+			}
+			if r.Y < 0 || r.Y > v.Y {
+				t.Errorf("Expected Y component to be in range [0, %d], got %d", v.Y, r.Y)
+			}
+		}
+	})
+	
+	t.Run("RandInInPlace should modify the vector in-place for V2I[int]", func(t *testing.T) {
+		v := V2I[int]{10, 20}
+		original := V2I[int]{v.X, v.Y}
+		
+		v.RandInInPlace()
+		
+		// Check that components are within range [0, original.X] and [0, original.Y]
+		if v.X < 0 || v.X > original.X {
+			t.Errorf("Expected X component to be in range [0, %d], got %d", original.X, v.X)
+		}
+		if v.Y < 0 || v.Y > original.Y {
+			t.Errorf("Expected Y component to be in range [0, %d], got %d", original.Y, v.Y)
+		}
+	})
+	
+	t.Run("RandIn should generate random values within range for V2I[int64]", func(t *testing.T) {
+		v := V2I[int64]{10, 20}
+		
+		// Generate multiple random vectors to ensure randomness
+		for i := 0; i < 10; i++ {
+			r := v.RandIn()
+			
+			// Check that components are within range [0, v.X] and [0, v.Y]
+			if r.X < 0 || r.X > v.X {
+				t.Errorf("Expected X component to be in range [0, %d], got %d", v.X, r.X)
+			}
+			if r.Y < 0 || r.Y > v.Y {
+				t.Errorf("Expected Y component to be in range [0, %d], got %d", v.Y, r.Y)
+			}
+		}
+	})
+}
+
+func Test_V3I_RandIn(t *testing.T) {
+	t.Run("RandIn should generate random values within range for V3I[int]", func(t *testing.T) {
+		v := V3I[int]{10, 20, 30}
+		
+		// Generate multiple random vectors to ensure randomness
+		for i := 0; i < 10; i++ {
+			r := v.RandIn()
+			
+			// Check that components are within range [0, v.X], [0, v.Y], and [0, v.Z]
+			if r.X < 0 || r.X > v.X {
+				t.Errorf("Expected X component to be in range [0, %d], got %d", v.X, r.X)
+			}
+			if r.Y < 0 || r.Y > v.Y {
+				t.Errorf("Expected Y component to be in range [0, %d], got %d", v.Y, r.Y)
+			}
+			if r.Z < 0 || r.Z > v.Z {
+				t.Errorf("Expected Z component to be in range [0, %d], got %d", v.Z, r.Z)
+			}
+		}
+	})
+	
+	t.Run("RandInInPlace should modify the vector in-place for V3I[int]", func(t *testing.T) {
+		v := V3I[int]{10, 20, 30}
+		original := V3I[int]{v.X, v.Y, v.Z}
+		
+		v.RandInInPlace()
+		
+		// Check that components are within range [0, original.X], [0, original.Y], and [0, original.Z]
+		if v.X < 0 || v.X > original.X {
+			t.Errorf("Expected X component to be in range [0, %d], got %d", original.X, v.X)
+		}
+		if v.Y < 0 || v.Y > original.Y {
+			t.Errorf("Expected Y component to be in range [0, %d], got %d", original.Y, v.Y)
+		}
+		if v.Z < 0 || v.Z > original.Z {
+			t.Errorf("Expected Z component to be in range [0, %d], got %d", original.Z, v.Z)
+		}
+	})
+	
+	t.Run("RandIn should generate random values within range for V3I[int64]", func(t *testing.T) {
+		v := V3I[int64]{10, 20, 30}
+		
+		// Generate multiple random vectors to ensure randomness
+		for i := 0; i < 10; i++ {
+			r := v.RandIn()
+			
+			// Check that components are within range [0, v.X], [0, v.Y], and [0, v.Z]
+			if r.X < 0 || r.X > v.X {
+				t.Errorf("Expected X component to be in range [0, %d], got %d", v.X, r.X)
+			}
+			if r.Y < 0 || r.Y > v.Y {
+				t.Errorf("Expected Y component to be in range [0, %d], got %d", v.Y, r.Y)
+			}
+			if r.Z < 0 || r.Z > v.Z {
+				t.Errorf("Expected Z component to be in range [0, %d], got %d", v.Z, r.Z)
+			}
+		}
+	})
+}


### PR DESCRIPTION
This PR implements the RandIn and RandBetween operations as described in issues #21 and #22.

## Changes

- Added `RandIn` operation that generates a vector with random components within a range specified by a vector and a zero vector
- Added `RandBetween` operation that generates a vector with random components within a range specified by two vectors
- Added comprehensive tests for both operations
- Updated README.md to mark these operations as implemented

Closes #21
Closes #22