### PR TITLE
Implement Lerp operation

### DIFF
--- a/lerp.go
+++ b/lerp.go
@@ -1,0 +1,64 @@
+package govec
+
+// V2F
+
+// Lerp returns a new V2F[T] that is a linear interpolation between v and v2 using t as the interpolation parameter.
+// t = 0 returns v, t = 1 returns v2, t = 0.5 returns the midpoint between v and v2.
+func (v V2F[T]) Lerp(v2 V2F[T], t T) V2F[T] {
+	return V2F[T]{
+		X: v.X + (v2.X-v.X)*t,
+		Y: v.Y + (v2.Y-v.Y)*t,
+	}
+}
+
+// LerpInPlace modifies v by linearly interpolating between v and v2 using t as the interpolation parameter.
+// t = 0 leaves v unchanged, t = 1 sets v to v2, t = 0.5 sets v to the midpoint between v and v2.
+func (v *V2F[T]) LerpInPlace(v2 V2F[T], t T) {
+	v.X = v.X + (v2.X-v.X)*t
+	v.Y = v.Y + (v2.Y-v.Y)*t
+}
+
+// V3F
+
+// Lerp returns a new V3F[T] that is a linear interpolation between v and v2 using t as the interpolation parameter.
+// t = 0 returns v, t = 1 returns v2, t = 0.5 returns the midpoint between v and v2.
+func (v V3F[T]) Lerp(v2 V3F[T], t T) V3F[T] {
+	return V3F[T]{
+		X: v.X + (v2.X-v.X)*t,
+		Y: v.Y + (v2.Y-v.Y)*t,
+		Z: v.Z + (v2.Z-v.Z)*t,
+	}
+}
+
+// LerpInPlace modifies v by linearly interpolating between v and v2 using t as the interpolation parameter.
+// t = 0 leaves v unchanged, t = 1 sets v to v2, t = 0.5 sets v to the midpoint between v and v2.
+func (v *V3F[T]) LerpInPlace(v2 V3F[T], t T) {
+	v.X = v.X + (v2.X-v.X)*t
+	v.Y = v.Y + (v2.Y-v.Y)*t
+	v.Z = v.Z + (v2.Z-v.Z)*t
+}
+
+// V2I
+
+// Lerp returns a new V2F[float64] that is a linear interpolation between v and v2 using t as the interpolation parameter.
+// t = 0 returns v, t = 1 returns v2, t = 0.5 returns the midpoint between v and v2.
+// Note: For integer vectors, Lerp returns a float vector.
+func (v V2I[T]) Lerp(v2 V2I[T], t float64) V2F[float64] {
+	return V2F[float64]{
+		X: float64(v.X) + (float64(v2.X)-float64(v.X))*t,
+		Y: float64(v.Y) + (float64(v2.Y)-float64(v.Y))*t,
+	}
+}
+
+// V3I
+
+// Lerp returns a new V3F[float64] that is a linear interpolation between v and v2 using t as the interpolation parameter.
+// t = 0 returns v, t = 1 returns v2, t = 0.5 returns the midpoint between v and v2.
+// Note: For integer vectors, Lerp returns a float vector.
+func (v V3I[T]) Lerp(v2 V3I[T], t float64) V3F[float64] {
+	return V3F[float64]{
+		X: float64(v.X) + (float64(v2.X)-float64(v.X))*t,
+		Y: float64(v.Y) + (float64(v2.Y)-float64(v.Y))*t,
+		Z: float64(v.Z) + (float64(v2.Z)-float64(v.Z))*t,
+	}
+}

--- a/lerp_test.go
+++ b/lerp_test.go
@@ -1,0 +1,166 @@
+package govec
+
+import (
+	"math"
+	"testing"
+)
+
+// Test V2F Lerp
+func TestV2F_Lerp(t *testing.T) {
+	v1 := V2F[float64]{X: 1.0, Y: 2.0}
+	v2 := V2F[float64]{X: 5.0, Y: 10.0}
+
+	// Test t = 0 (should return v1)
+	v3 := v1.Lerp(v2, 0.0)
+	if v3.X != 1.0 || v3.Y != 2.0 {
+		t.Errorf("V2F Lerp with t=0 failed, got %v, expected %v", v3, v1)
+	}
+
+	// Test t = 1 (should return v2)
+	v3 = v1.Lerp(v2, 1.0)
+	if v3.X != 5.0 || v3.Y != 10.0 {
+		t.Errorf("V2F Lerp with t=1 failed, got %v, expected %v", v3, v2)
+	}
+
+	// Test t = 0.5 (should return midpoint)
+	v3 = v1.Lerp(v2, 0.5)
+	if v3.X != 3.0 || v3.Y != 6.0 {
+		t.Errorf("V2F Lerp with t=0.5 failed, got %v, expected {3.0, 6.0}", v3)
+	}
+
+	// Test t = 0.25
+	v3 = v1.Lerp(v2, 0.25)
+	if v3.X != 2.0 || v3.Y != 4.0 {
+		t.Errorf("V2F Lerp with t=0.25 failed, got %v, expected {2.0, 4.0}", v3)
+	}
+}
+
+func TestV2F_LerpInPlace(t *testing.T) {
+	v1 := V2F[float64]{X: 1.0, Y: 2.0}
+	v2 := V2F[float64]{X: 5.0, Y: 10.0}
+	original := V2F[float64]{X: 1.0, Y: 2.0}
+
+	// Test t = 0 (should leave v1 unchanged)
+	v1.LerpInPlace(v2, 0.0)
+	if v1.X != original.X || v1.Y != original.Y {
+		t.Errorf("V2F LerpInPlace with t=0 failed, got %v, expected %v", v1, original)
+	}
+
+	// Test t = 1 (should set v1 to v2)
+	v1 = original
+	v1.LerpInPlace(v2, 1.0)
+	if v1.X != v2.X || v1.Y != v2.Y {
+		t.Errorf("V2F LerpInPlace with t=1 failed, got %v, expected %v", v1, v2)
+	}
+
+	// Test t = 0.5 (should set v1 to midpoint)
+	v1 = original
+	v1.LerpInPlace(v2, 0.5)
+	if v1.X != 3.0 || v1.Y != 6.0 {
+		t.Errorf("V2F LerpInPlace with t=0.5 failed, got %v, expected {3.0, 6.0}", v1)
+	}
+}
+
+// Test V3F Lerp
+func TestV3F_Lerp(t *testing.T) {
+	v1 := V3F[float64]{X: 1.0, Y: 2.0, Z: 3.0}
+	v2 := V3F[float64]{X: 5.0, Y: 10.0, Z: 15.0}
+
+	// Test t = 0 (should return v1)
+	v3 := v1.Lerp(v2, 0.0)
+	if v3.X != 1.0 || v3.Y != 2.0 || v3.Z != 3.0 {
+		t.Errorf("V3F Lerp with t=0 failed, got %v, expected %v", v3, v1)
+	}
+
+	// Test t = 1 (should return v2)
+	v3 = v1.Lerp(v2, 1.0)
+	if v3.X != 5.0 || v3.Y != 10.0 || v3.Z != 15.0 {
+		t.Errorf("V3F Lerp with t=1 failed, got %v, expected %v", v3, v2)
+	}
+
+	// Test t = 0.5 (should return midpoint)
+	v3 = v1.Lerp(v2, 0.5)
+	if v3.X != 3.0 || v3.Y != 6.0 || v3.Z != 9.0 {
+		t.Errorf("V3F Lerp with t=0.5 failed, got %v, expected {3.0, 6.0, 9.0}", v3)
+	}
+}
+
+func TestV3F_LerpInPlace(t *testing.T) {
+	v1 := V3F[float64]{X: 1.0, Y: 2.0, Z: 3.0}
+	v2 := V3F[float64]{X: 5.0, Y: 10.0, Z: 15.0}
+	original := V3F[float64]{X: 1.0, Y: 2.0, Z: 3.0}
+
+	// Test t = 0 (should leave v1 unchanged)
+	v1.LerpInPlace(v2, 0.0)
+	if v1.X != original.X || v1.Y != original.Y || v1.Z != original.Z {
+		t.Errorf("V3F LerpInPlace with t=0 failed, got %v, expected %v", v1, original)
+	}
+
+	// Test t = 1 (should set v1 to v2)
+	v1 = original
+	v1.LerpInPlace(v2, 1.0)
+	if v1.X != v2.X || v1.Y != v2.Y || v1.Z != v2.Z {
+		t.Errorf("V3F LerpInPlace with t=1 failed, got %v, expected %v", v1, v2)
+	}
+
+	// Test t = 0.5 (should set v1 to midpoint)
+	v1 = original
+	v1.LerpInPlace(v2, 0.5)
+	if v1.X != 3.0 || v1.Y != 6.0 || v1.Z != 9.0 {
+		t.Errorf("V3F LerpInPlace with t=0.5 failed, got %v, expected {3.0, 6.0, 9.0}", v1)
+	}
+}
+
+// Test V2I Lerp
+func TestV2I_Lerp(t *testing.T) {
+	v1 := V2I[int]{X: 1, Y: 2}
+	v2 := V2I[int]{X: 5, Y: 10}
+
+	// Test t = 0 (should return v1 as float)
+	v3 := v1.Lerp(v2, 0.0)
+	if v3.X != 1.0 || v3.Y != 2.0 {
+		t.Errorf("V2I Lerp with t=0 failed, got %v, expected {1.0, 2.0}", v3)
+	}
+
+	// Test t = 1 (should return v2 as float)
+	v3 = v1.Lerp(v2, 1.0)
+	if v3.X != 5.0 || v3.Y != 10.0 {
+		t.Errorf("V2I Lerp with t=1 failed, got %v, expected {5.0, 10.0}", v3)
+	}
+
+	// Test t = 0.5 (should return midpoint as float)
+	v3 = v1.Lerp(v2, 0.5)
+	if v3.X != 3.0 || v3.Y != 6.0 {
+		t.Errorf("V2I Lerp with t=0.5 failed, got %v, expected {3.0, 6.0}", v3)
+	}
+
+	// Test t = 0.25 (should return quarter point as float)
+	v3 = v1.Lerp(v2, 0.25)
+	if math.Abs(v3.X-2.0) > 1e-10 || math.Abs(v3.Y-4.0) > 1e-10 {
+		t.Errorf("V2I Lerp with t=0.25 failed, got %v, expected {2.0, 4.0}", v3)
+	}
+}
+
+// Test V3I Lerp
+func TestV3I_Lerp(t *testing.T) {
+	v1 := V3I[int]{X: 1, Y: 2, Z: 3}
+	v2 := V3I[int]{X: 5, Y: 10, Z: 15}
+
+	// Test t = 0 (should return v1 as float)
+	v3 := v1.Lerp(v2, 0.0)
+	if v3.X != 1.0 || v3.Y != 2.0 || v3.Z != 3.0 {
+		t.Errorf("V3I Lerp with t=0 failed, got %v, expected {1.0, 2.0, 3.0}", v3)
+	}
+
+	// Test t = 1 (should return v2 as float)
+	v3 = v1.Lerp(v2, 1.0)
+	if v3.X != 5.0 || v3.Y != 10.0 || v3.Z != 15.0 {
+		t.Errorf("V3I Lerp with t=1 failed, got %v, expected {5.0, 10.0, 15.0}", v3)
+	}
+
+	// Test t = 0.5 (should return midpoint as float)
+	v3 = v1.Lerp(v2, 0.5)
+	if v3.X != 3.0 || v3.Y != 6.0 || v3.Z != 9.0 {
+		t.Errorf("V3I Lerp with t=0.5 failed, got %v, expected {3.0, 6.0, 9.0}", v3)
+	}
+}


### PR DESCRIPTION
Closes #19

Implemented the Lerp (Linear Interpolation) operation for all vector types. For integer vectors, the operation returns a float vector as specified in the issue.

Added comprehensive tests for all vector types and various interpolation parameters.